### PR TITLE
Add HTML prototype for MAESTRO specs

### DIFF
--- a/prototype-specs.html
+++ b/prototype-specs.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>MAESTRO — Detailed Specs (Offline)</title>
+<style>
+body{margin:0;padding:20px;font-family:Segoe UI,Roboto,Arial,sans-serif;background:#f6f8fb;color:#1f2a44;line-height:1.6}
+h1,h2,h3,h4{color:#0a6ed1}
+pre{background:#fff;border:1px solid #e3e8f0;padding:12px;border-radius:8px;overflow:auto}
+code{font-family:Consolas,monospace}
+</style>
+</head>
+<body>
+<h2>Aperçu détaillé des fonctionnalités</h2>
+<h3>Architecture</h3>
+<ul>
+<li><strong>Prototype autonome en un seul fichier</strong> — <code>prototype.html</code> regroupe HTML, CSS et JavaScript Vanilla pour fonctionner entièrement dans le navigateur sans dépendance externe.</li>
+<li><strong>Objet d'état central (<code>S</code>)</strong> — Contient les listes de données maîtres (<code>mdLists</code>), les correspondances entre types de demandes et opérations requises, les durées d'opérations par défaut, les capacités des ateliers et les données dynamiques pour les demandes et opérations.</li>
+</ul>
+<h3>Modèle de données et remplissage initial</h3>
+<ul>
+<li><strong>Données de référence (seedMasterData)</strong></li>
+<li>Précharge les listes Urgence, Statut, Atelier, Lieu, Type d'opération, Modèle de moteur, Client et Type de demande.</li>
+<li>Construit la correspondance <code>requestTypeToOps</code> (chaque type de demande → quatre types d'opérations obligatoires).</li>
+<li>
+<p>Stocke les durées par défaut (<code>opDur</code>) et les capacités par atelier (opérations autorisées, capacité par défaut, localisation, exceptions de capacité).</p>
+</li>
+<li>
+<p><strong>Données transactionnelles (seedTransactions)</strong></p>
+</li>
+<li>Génère 10 demandes d'exemple avec calcul des dates de fin estimées en fonction des opérations requises.</li>
+<li>Crée 30 opérations d'exemple liées aux demandes, en respectant les capacités des ateliers et un planning aléatoire.</li>
+</ul>
+<h3>Écrans de l'UI</h3>
+<ol>
+<li><strong>Formulaire Nouvelle Demande</strong></li>
+<li>Attribue automatiquement les identifiants de demande.</li>
+<li>Listes déroulantes dynamiques basées sur les données maîtres.</li>
+<li>Calcule la date de fin estimée à partir des opérations requises.</li>
+<li>
+<p>Volet d'aide indiquant les opérations requises et une « recherche de capacité » pour vérifier la disponibilité par date, atelier et type d'opération.</p>
+</li>
+<li>
+<p><strong>Formulaire d'édition d'opérations</strong></p>
+</li>
+<li>Attribue automatiquement les identifiants d'opération.</li>
+<li>Filtre les types d'opération en fonction de l'atelier choisi.</li>
+<li>Calcule automatiquement la date de fin à partir de la date de début et de la durée.</li>
+<li>
+<p>Volet d'aide listant les opérations autorisées par atelier et la capacité par défaut.</p>
+</li>
+<li>
+<p><strong>Tableau des demandes</strong></p>
+</li>
+<li>Recherche par identifiant de demande.</li>
+<li>
+<p>Affiche le nombre d'opérations liées ; clic sur les identifiants pour naviguer vers des vues filtrées.</p>
+</li>
+<li>
+<p><strong>Tableau des opérations</strong></p>
+</li>
+<li>Recherche par identifiant d'opération ou de demande.</li>
+<li>
+<p>Clic sur les identifiants pour naviguer vers le tableau des demandes ou le formulaire d'édition prérempli.</p>
+</li>
+<li>
+<p><strong>Éditeur de données maîtres</strong></p>
+</li>
+<li>Colonnes de texte pour chaque liste maîtresse.</li>
+<li>Mapping éditable : Type de demande ↔ quatre types d'opérations (unicité garantie).</li>
+<li>Durées par défaut éditables pour chaque type d'opération.</li>
+<li>« Appliquer les modifications MD » recalculant les données dépendantes et rafraîchissant l'interface.</li>
+<li>
+<p>Visualiseur JSON en lecture seule avec copie/téléchargement.</p>
+</li>
+<li>
+<p><strong>Tableau de bord KPI</strong></p>
+</li>
+<li>Calcule le pourcentage de demandes urgentes livrées à temps.</li>
+<li>Carte de chaleur de capacité hebdomadaire (Lieu × Atelier) pour les 8 semaines à venir avec code couleur selon l'utilisation.</li>
+</ol>
+<h3>Fonctionnalités utilitaires et de persistance</h3>
+<ul>
+<li>Identifiants générés automatiquement (<code>nextRequestId</code>, <code>nextOpId</code>).</li>
+<li>Formatage des dates et calcul des semaines ISO pour la logique de capacité.</li>
+<li>Import/export JSON de l'état complet.</li>
+<li>Les liaisons d'événements gèrent les actions de formulaire, le filtrage des tableaux et les mises à jour des données maîtres.</li>
+</ul>
+<h2>Diagramme de classes UML (Mermaid)</h2>
+<pre><code class="language-mermaid">classDiagram
+    class Request {
+        +String id
+        +String customer
+        +String engine
+        +String location
+        +String shop
+        +String requestType
+        +String urgency
+        +String status
+        +Date requestDate
+        +Date estEnd
+        +String notes
+    }
+
+    class Operation {
+        +String id
+        +String reqId
+        +String shop
+        +String opType
+        +String status
+        +Date start
+        +Date finish
+        +Number duration
+    }
+
+    class ShopCapability {
+        +String shop
+        +String location
+        +Number defaultCapacity
+        +List&lt;Exception&gt; exceptions
+        +List&lt;String&gt; allowedOps
+    }
+
+    class RequestType {
+        +String name
+        +List&lt;String&gt; requiredOps (4)
+    }
+
+    class OperationType {
+        +String name
+        +Number defaultDuration
+    }
+
+    Request &quot;1&quot; --&gt; &quot;many&quot; Operation : contient
+    ShopCapability &quot;1&quot; --&gt; &quot;many&quot; Operation : planifiée à
+    RequestType &quot;1&quot; --&gt; &quot;4&quot; OperationType : requiert
+    ShopCapability &quot;1&quot; --&gt; &quot;many&quot; OperationType : autorise
+</code></pre>
+<h2>Fonctionnalités du dépôt</h2>
+<ul>
+<li><strong>Périmètre du projet</strong> – Ce dépôt guide les utilisateurs pour construire des prototypes HTML autonomes avec GPT. Il fournit un questionnaire, un exemple de prompt et un fichier prototype fonctionnel pour valider des idées produit hors ligne sans dépendances externes.</li>
+<li><strong>Prototype MAESTRO</strong> – Le prompt et le HTML inclus illustrent un outil de maintenance pour moteurs d'avion. Il définit les objets métier (Demandes, Opérations, listes maîtres, mappings), les relations de données et des enregistrements d'exemple préremplis pour simuler des scénarios réels.</li>
+<li><strong>Interface utilisateur &amp; navigation</strong> – Le prototype présente plusieurs écrans (formulaire Nouvelle Demande, éditeur d'Opérations, tableaux Demandes/Opérations, éditeur de données maîtres, tableau de bord KPI) accessibles via une barre d'onglets. Les tableaux prennent en charge le filtrage et la navigation croisée via les liens d'ID.</li>
+<li><strong>Fonctionnalités interactives</strong> – Les fonctions JavaScript activent les listes déroulantes dynamiques, les recherches de capacité, le calcul automatique des dates et les liaisons d'événements pour créer, éditer et lier des enregistrements de maintenance.</li>
+<li><strong>Utilitaires de persistance des données</strong> – Les utilisateurs peuvent exporter et importer l'ensemble des données au format JSON directement depuis l'interface, ce qui permet une utilisation hors ligne et un partage facile des données.</li>
+</ul>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- generate `prototype-specs.html` converting `specs.md` into standalone HTML with light styling

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fca6873e08326a81be323ff88e494